### PR TITLE
fix TopoJSON default scale & translate

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -131,8 +131,8 @@ def extract_lines(gj: dict):
             yield line
     elif gj_type == 'Topology':
         transform = gj.get('transform', {})
-        scale = transform.get('scale', 1.0)
-        translate = transform.get('translate', 1.0)
+        scale = transform.get('scale', [1.0, 1.0])
+        translate = transform.get('translate', [0.0, 0.0])
         for arc in gj['arcs']:
             line = []
             prev = [0, 0]


### PR DESCRIPTION
If there is no scale present in the TopoJSON file,
we should assume [1.0, 1.0] (100%).

If there is no translation distance in the TopoJSON file,
we should assume [0.0, 0.0] translation not 1.0.